### PR TITLE
drop alpine edge repos from builder since 3.2 is official

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,5 @@
 FROM alpine:latest
 
-# To build caddy requires go 1.4, which is provided by Edge.
-COPY repositories /etc/apk/repositories
-
 RUN apk upgrade --update --available && \
     apk add \
       ca-certificates \

--- a/repositories
+++ b/repositories
@@ -1,5 +1,0 @@
-# We need edge to get go >= 1.4 for build.
-# This is used for the builder, not the runtime.
-http://dl-4.alpinelinux.org/alpine/v3.1/main
-http://dl-4.alpinelinux.org/alpine/edge/main
-http://dl-4.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
Alpine 3.2 includes go 1.4.2, which satisfies build requirements.
Therefore we do not need testing repos.

This has the side effect of building the latest version of caddy.
