### PR TITLE
build with go >= 1.4.3 to resolve CVE in net/http

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -28,4 +28,7 @@ RUN source /home/developer/CADDY_VERSION && \
     go get -d github.com/mholt/caddy && \
     cd /home/developer/src/github.com/mholt/caddy && \
     git checkout ${CADDY_VERSION} && \
+    git config --global user.email "you@example.com" && \
+    git config --global user.name "Your Name" && \
+    git cherry-pick 0ca0d552ebe0740eba62772a289e13c6f8496684 && \
     go build -a -installsuffix cgo -tags netgo -ldflags '-w' -o /home/developer/bin/caddy

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,17 +6,17 @@ ENV GOPATH /home/developer
 ENV CGO_ENABLED 0
 ENV GOOS linux
 
+RUN echo '@edge http://dl-4.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
 RUN apk upgrade --update --available && \
     apk add \
       ca-certificates \
       git \
-      go \
+      'go@edge>=1.4.3' \
       openssl=${OPENSSL_VERSION} \
     && rm -f /var/cache/apk/*
 
 RUN adduser -D developer
-# https://github.com/golang/go/issues/10210
-#USER developer
+USER developer
 WORKDIR /home/developer
 
 # This file is where we define the caddy version.


### PR DESCRIPTION
The CVE and updates were announced at
https://groups.google.com/forum/#!topic/golang-announce/iSIyW4lM4hY

> The issues were reported in Go's net/http package. They affect
> programs using that package to proxy HTTP requests. We recommend
> that all users upgrade to Go 1.5, which fixes these issues. For
> users unable to upgrade to Go 1.5, we have released version 1.4.3,
> which is based on Go 1.4.2 plus fixes for these issues. Affected
> Go programs—those that use the net/http package as a proxy
> server—must be recompiled with Go 1.5 or Go 1.4.3 to receive
> the fixes.

The CVE issue descriptions and fixes are linked below.

CVE-2015-5739
"Content Length" treated as valid header:
https://go-review.googlesource.com/#/c/11772/

CVE-2015-5740
Double content-length headers does not return 400 error:
https://go-review.googlesource.com/#/c/11810/

CVE-2015-5741
Additional hardening, not sending Content-Length w/Transfer-Encoding,
Closing connections:
https://go-review.googlesource.com/#/c/11810/
https://go-review.googlesource.com/#/c/12865/
https://go-review.googlesource.com/#/c/13148/
