### PR TITLE
use docker version that is default on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,5 @@
 # https://circleci.com/docs/docker
 machine:
-  pre:
-    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.2-circleci'
-    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 


### PR DESCRIPTION
circle now has 1.6.2 by default
