### PR TITLE
show how to restrict http methods for web security

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ Output of `make test` resembles:
     ✓ caddy binary is statically compiled
     ✓ upload plugin is present
     ✓ upload works
+    ✓ move works
+    ✓ head is forbidden
 
-    9 tests, 0 failures, 1 skipped
+    11 tests, 0 failures, 1 skipped
 
 The securityheaders.io test requires inbound access from the internet to port 80.
 If you have inbound access and want to run the securityheaders.io test,

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Output of `make test` resembles:
 
     11 tests, 0 failures, 1 skipped
 
+The test harness uses an example caddyfile at [`fixtures/caddyfile`](fixtures/caddyfile)
+to demonstrate ways to secure a Caddy-based site according to
+good industry practices.
+The test harness does not use TLS at the moment.
+
 The securityheaders.io test requires inbound access from the internet to port 80.
 If you have inbound access and want to run the securityheaders.io test,
 create `test/env.bash` like this:

--- a/fixtures/caddyfile
+++ b/fixtures/caddyfile
@@ -9,9 +9,37 @@ root /home/caddy
 # Render markdown files as html.
 markdown /
 
+# Provide custom URL that returns status 405 "Method not allowed".
+# Then we can conditionally rewrite paths to this URL.
+status 405 /forbidden
+
 upload /uploads {
   yes_without_tls
   to "/home/caddy"
+}
+
+# Allow /uploads to use the verbs it needs.
+rewrite /uploads {
+  if {method} not GET
+  if {method} not PUT
+  if {method} not POST
+  if {method} not MOVE
+  if {method} not DELETE
+
+  if_op and
+  to /forbidden
+}
+
+# All other URLs are only allowed to GET.
+#
+# Use https://www.htbridge.com/websec/
+# to check security of public sites.
+rewrite {
+  if {method} not GET
+  if {path} not_match ^/uploads
+
+  if_op and
+  to /forbidden
 }
 
 # Clone a public repo once/hour.

--- a/test/upload.bats
+++ b/test/upload.bats
@@ -1,3 +1,7 @@
+setup() {
+  ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' caddy)
+}
+
 @test "upload plugin is present" {
   run docker run --rm -t --entrypoint=caddy jumanjiman/caddy -plugins
   [[ $output =~ http.upload ]]
@@ -5,9 +9,20 @@
 
 @test "upload works" {
   rm -f /tmp/myrelease || :
-  ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' caddy)
   curl -T /etc/os-release http://${ip}:2020/uploads/myrelease
   curl -o /tmp/myrelease http://${ip}:2020/myrelease
   cmp /tmp/myrelease /etc/os-release
   [[ $status -eq 0 ]]
+}
+
+@test "move works" {
+  curl -X MOVE -H "Destination: /uploads/newrelease" http://${ip}:2020/uploads/myrelease
+  curl -o /tmp/newrelease http://${ip}:2020/newrelease
+  cmp /tmp/myrelease /tmp/newrelease
+  [[ $status -eq 0 ]]
+}
+
+@test "head is forbidden" {
+  run curl --fail --head http://${ip}:2020/ 2>&1
+  [[ $output =~ 405 ]]
 }


### PR DESCRIPTION
Background: Many security organizations recommend that web sites
allow only the HTTP methods (verbs) that are absolutely required.

Scenario: The test fixtures site needs GET for all pages, plus
PUT/POST/MOVE/DELETE for the uploads functionality.

This commit shows how to allow the verbs for upload functionality
yet restrict the verbs to GET for all other URLs.
