### PR TITLE
show how to log more verbosely

### DIFF
--- a/fixtures/caddyfile
+++ b/fixtures/caddyfile
@@ -1,7 +1,9 @@
 # https://caddyserver.com/docs/caddyfile
 0.0.0.0:2020
-log stdout
 errors stderr
+
+# This directive supports https://caddyserver.com/docs/placeholders
+log / stdout "{remote} - [{when}] \"{method} {uri} {proto}\" {status} {size} {latency} {request}"
 
 # After this line, all other paths are relative to root.
 root /home/caddy


### PR DESCRIPTION
This format is similar to the default "{common}", but
adds response latency and full request as sent by the client.

This is useful to see what really happens on the server.
For example, the fixtures/caddyfile rejects the HEAD verb.

With default log option, you do not see what the client requested:

    172.17.0.2 - [27/Nov/2016:22:44:51 +0000] \
    "HEAD /forbidden HTTP/1.1" 405 23

With new, verbose log option from this commit, you see that
the client requested "HEAD /":

    172.17.0.2 - [27/Nov/2016:22:44:51 +0000] \
    "HEAD /forbidden HTTP/1.1" 405 23 \
    494µs \
    HEAD / HTTP/1.1\r\n \
    Host: 172.17.0.3:2020\r\n \
    Accept: */*\r\n \
    Caddy-Rewrite-Original-Uri: /\r\n \
    User-Agent: curl/7.51.0\r\n\r\n