### PR TITLE
really strip the built binary and improve test

### DIFF
--- a/builder/static.patch
+++ b/builder/static.patch
@@ -7,4 +7,4 @@ index f55a988..1bdf76f 100755
  ldflags+=("-X" "\"${name}=${value}\"")
  
 -go build -ldflags "${ldflags[*]}" -o "${output_filename}"
-+go build -ldflags "${ldflags[*]}" -o "${output_filename}" -buildmode=exe
++go build -ldflags "${ldflags[*]} -extldflags '-static' -s" -o "${output_filename}" -buildmode=exe

--- a/test/static.bats
+++ b/test/static.bats
@@ -11,6 +11,7 @@
 @test "caddy binary is stripped" {
   run file runtime/caddy
   [[ $output =~ stripped ]]
+  [[ ! $output =~ 'not stripped' ]]
 }
 
 @test "caddy binary is statically compiled" {


### PR DESCRIPTION
Before this commit: The caddy binary is 16 MiB and not stripped:

    -rwxr-xr-x 1 user user 16376999 Dec 24 18:09 runtime/caddy
    runtime/caddy: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped

After this commit: The caddy binary is 10 MiB and stripped:

    -rwxr-xr-x 1 user user 10286528 Dec 24 18:11 runtime/caddy
    runtime/caddy: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped