### PR TITLE
runtime: provide a minimal default caddyfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean: stop
 stop:
 	@docker rm -f caddy || :
 	@docker rm -f caddyfile || :
+	@docker rm -f caddy2 || :
 
 runtime/caddy:
 	@docker build -t caddybuild builder/
@@ -49,12 +50,27 @@ ifdef CIRCLECI
 		--read-only \
 		-p 80:2020 \
 		jumanjiman/caddy -conf /etc/caddy/caddyfile
+
+	# Default caddyfile from image.
+	@docker run -d \
+		--name caddy2 \
+		--read-only \
+		-p 81:2020 \
+		jumanjiman/caddy -conf /etc/caddy/caddyfile
 else
 	@docker run -d \
 		--name caddy \
 		--volumes-from caddyfile \
 		--read-only \
 		-p 80:2020 \
+		--cap-drop all \
+		jumanjiman/caddy -conf /etc/caddy/caddyfile
+
+	# Default caddyfile from image.
+	@docker run -d \
+		--name caddy2 \
+		--read-only \
+		-p 81:2020 \
 		--cap-drop all \
 		jumanjiman/caddy -conf /etc/caddy/caddyfile
 endif

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Output of `make test` resembles:
 
     ✓ caddy image exists
     ✓ caddy is running on the test port
+    ✓ caddy2 is running on the test port
+    ✓ see hello world with default config
     ✓ git plugin is installed
     ✓ git plugin works
     ✓ can browse docker-caddy path
@@ -83,7 +85,7 @@ Output of `make test` resembles:
     ✓ move works
     ✓ head is forbidden
 
-    15 tests, 0 failures, 2 skipped
+    17 tests, 0 failures, 2 skipped
 
 The test harness uses an example caddyfile at [`fixtures/caddyfile`](fixtures/caddyfile)
 to demonstrate ways to secure a Caddy-based site according to
@@ -132,4 +134,15 @@ Create a config in some directory on your host, then:
     -v /path/to/configdir:/etc/caddy \
     --read-only \
     --cap-drop all \
+    jumanjiman/caddy -conf /etc/caddy/caddyfile
+
+Alternatively, use the minimal default [caddyfile](runtime/caddyfile) from the image
+to just serve files from `/home/caddy`:
+
+    docker run -d \
+    -p 2020:2020 \
+    --name caddy \
+    --read-only \
+    --cap-drop all \
+    -v /path/to/your/files:/home/caddy:ro \
     jumanjiman/caddy -conf /etc/caddy/caddyfile

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -23,6 +23,7 @@ RUN apk upgrade --no-cache --available && \
     && adduser -Du 1000 caddy
 
 RUN echo "hello world" > /home/caddy/index.html
+COPY caddyfile /etc/caddy/
 
 VOLUME ["/etc/caddy"]
 VOLUME ["/home/caddy"]

--- a/runtime/caddyfile
+++ b/runtime/caddyfile
@@ -1,0 +1,74 @@
+# https://caddyserver.com/docs/caddyfile
+0.0.0.0:2020
+errors stderr
+
+# This directive supports https://caddyserver.com/docs/placeholders
+log / stdout "{remote} - [{when}] \"{method} {uri} {proto}\" {status} {size} {latency} {request}"
+
+# After this line, all other paths are relative to root.
+root /home/caddy
+
+# Render markdown files as html.
+markdown /
+
+# Allow browsing in this dir.
+browse /files/
+
+# Provide custom URL that returns status 405 "Method not allowed".
+# Then we can conditionally rewrite paths to this URL.
+status 405 /forbidden
+
+# All URLs are only allowed to GET.
+#
+# Use https://www.htbridge.com/websec/
+# to check security of public sites.
+rewrite {
+  if {method} not GET
+  to /forbidden
+}
+
+# Headers for all paths to demonstrate reasonable safety.
+# This fixture does not use TLS, so we omit recommended headers for https.
+# https://caddyserver.com/docs/header
+header / {
+  # CSP and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
+  # tell the browser that it can only download content from the domains we explicitly allow
+  # https://scotthelme.co.uk/content-security-policy-an-introduction/
+  # http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+  # https://www.owasp.org/index.php/Content_Security_Policy
+  # https://report-uri.io/home/generate
+  # https://csp-evaluator.withgoogle.com/
+  Content-Security-Policy "default-src 'self'; object-src 'none'; block-all-mixed-content; reflected-xss block;"
+
+  # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+  Referrer-Policy "strict-origin-when-cross-origin"
+
+  # Don't allow the browser to render our pages inside a frame or iframe
+  # thus avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+  # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options
+  # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+  X-Frame-Options "SAMEORIGIN"
+
+  # Enable the XSS filter built into most recent web browsers.
+  # It's usually enabled by default anyway, but this header
+  # re-enables the filter if it was disabled by the user.
+  # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection
+  # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+  X-Xss-Protection "1; mode=block"
+
+  # Prevent Google Chrome and Internet Explorer from trying
+  # to mime-sniff the content-type of a response away from
+  # the one being declared by the server.
+  # It reduces exposure to drive-by downloads and the risks
+  # of user uploaded content that, with clever naming,
+  # could be treated as a different content-type, like an executable.
+  # https://scotthelme.co.uk/hardening-your-http-response-headers/#x-content-type-options
+  # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+  # IE > 8 http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx
+  # http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
+  # 'soon' on Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=471020
+  X-Content-Type-Options "nosniff"
+
+  # Do not disclose which server we are.
+  -Server
+}

--- a/test/caddy.bats
+++ b/test/caddy.bats
@@ -7,3 +7,8 @@
   run docker logs caddy
   [[ $output =~ 0.0.0.0:2020 ]]
 }
+
+@test "caddy2 is running on the test port" {
+  run docker logs caddy2
+  [[ $output =~ 0.0.0.0:2020 ]]
+}

--- a/test/default_config.bats
+++ b/test/default_config.bats
@@ -1,0 +1,8 @@
+setup() {
+  ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' caddy2)
+}
+
+@test "see hello world with default config" {
+  run curl --fail -sS -L http://${ip}:2020/
+  [[ $output =~ "hello world" ]]
+}


### PR DESCRIPTION
This default allows to use the image to serve out files
from an arbitrary volume via HTTP GET, which is quick and easy
for those times when you don't want to create your own caddyfile.