### PR TITLE
runtime: use the default config by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ ifdef CIRCLECI
 		--volumes-from caddyfile \
 		--read-only \
 		-p 80:2020 \
-		jumanjiman/caddy -conf /etc/caddy/caddyfile
+		jumanjiman/caddy
 
 	# Default caddyfile from image.
 	@docker run -d \
 		--name caddy2 \
 		--read-only \
 		-p 81:2020 \
-		jumanjiman/caddy -conf /etc/caddy/caddyfile
+		jumanjiman/caddy
 else
 	@docker run -d \
 		--name caddy \
@@ -64,7 +64,7 @@ else
 		--read-only \
 		-p 80:2020 \
 		--cap-drop all \
-		jumanjiman/caddy -conf /etc/caddy/caddyfile
+		jumanjiman/caddy
 
 	# Default caddyfile from image.
 	@docker run -d \
@@ -72,7 +72,7 @@ else
 		--read-only \
 		-p 81:2020 \
 		--cap-drop all \
-		jumanjiman/caddy -conf /etc/caddy/caddyfile
+		jumanjiman/caddy
 endif
 	sleep 5
 	bats test/*.bats

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -33,3 +33,4 @@ COPY caddy /usr/sbin/caddy
 # Run as an unprivileged user.
 USER caddy
 ENTRYPOINT ["/usr/sbin/caddy"]
+CMD ["-conf", "/etc/caddy/caddyfile"]


### PR DESCRIPTION
The container uses the default config if you don't specify CLI options.
This should not break any current usage of the container because:

* Before this commit, you _must_ specify CLI options, and
* Your CLI options override the default.