### PR TITLE
caddy-git at a specific revision

### DIFF
--- a/builder/compile.sh
+++ b/builder/compile.sh
@@ -22,9 +22,13 @@ git config --global http.https://gopkg.in.followRedirects true
 # Fetch dependencies.
 go get -d ./...
 
+# run go-getter after the deps have been fetched above
+# https://github.com/joewalnes/go-getter
+cd /home/developer && ./go-getter gofile
+
 # Build!
 mkdir /home/developer/bin/
-cd caddy
+cd /home/developer/src/github.com/mholt/caddy/caddy
 go run build.go
 
 cp /home/developer/src/github.com/mholt/caddy/caddy/caddy /home/developer/bin/

--- a/builder/go-getter
+++ b/builder/go-getter
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Like 'go get' but with pinned package versions. https://github.com/joewalnes/go-getter
+set -e
+: ${GOPATH?"GOPATH not set"}
+: ${1?"Usage: $0 [path-to-go-deps]"}
+sed -e 's/#.*//' $1 | grep -v -e '^[[:space:]]*$' | while read PKG HASH; do
+  echo "$PKG ($HASH)"
+  DEST=$GOPATH/src/$PKG
+  go get -d -v -u $PKG || :
+  FOUND_VCS=0
+  while [[ "$DEST" != "$GOPATH/src" ]] && [[ -d $DEST ]]
+  do
+    cd $DEST
+    if [ -d "$DEST/.git" ]; then
+      FOUND_VCS=1
+      git checkout -q $HASH
+      break
+    elif [ -d "$DEST/.hg" ]; then
+      FOUND_VCS=1
+      hg update -q -c $HASH
+      break
+    elif [ -d "$DEST/.bzr" ]; then
+      FOUND_VCS=1
+      bzr update -q -r $HASH
+      break
+    elif [ -d "$DEST/.svn" ]; then
+      FOUND_VCS=1
+      svn update -q -r $HASH
+      break
+    else
+      DEST="$(readlink -f $DEST/..)"
+    fi
+  done
+  if [ $FOUND_VCS -eq 0 ]; then
+    echo "WARNING: Unrecognized VCS system for the golang package $PKG"
+  fi
+done
+

--- a/builder/gofile
+++ b/builder/gofile
@@ -1,0 +1,1 @@
+github.com/abiosoft/caddy-git    186c1c7e0b3c8e3c1edae20e45a782acddb37660


### PR DESCRIPTION
caddy-git is unable to clone repos with non-standard port URL as
documented in https://github.com/abiosoft/caddy-git/issues/76

This commit only attempts to provide a workaround for
this specific use case.

caddy-git is now at a [specific revision](https://github.com/abiosoft/caddy-git/tree/186c1c7e0b3c8e3c1edae20e45a782acddb37660) which does not have this issue.

This commit uses [go-getter](https://github.com/joewalnes/go-getter) to fetch caddy-git at a
specific revision

WARNING: this version of caddy-git is a few revisions behind and
may contain some known issues addressed by more recent commits.