### PR TITLE
add http.cache plugin along with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ to learn about Caddy.
 
 The following plugins are installed in the image:
 
+* [http.cache](https://caddyserver.com/docs/http.cache)
 * [http.cgi](https://github.com/jung-kurt/caddy-cgi)
 * [http.git](https://github.com/abiosoft/caddy-git)
 * [http.upload](https://github.com/wmark/caddy.upload)

--- a/fixtures/caddyfile
+++ b/fixtures/caddyfile
@@ -3,7 +3,7 @@
 errors stderr
 
 # This directive supports https://caddyserver.com/docs/placeholders
-log / stdout "{remote} - [{when}] \"{method} {uri} {proto}\" {status} {size} {latency} {request}"
+log / stdout "[{when}] remote \"{remote}\" method \"{method}\" uri \"{uri}\" proto \"{proto}\" status {status} size {size} latency {latency} request \"{request}\" upstream \"{upstream}\" cache_status \"{cache_status}\""
 
 # https://caddyserver.com/docs/timeouts
 # Show the defaults here just to show that we have RTFD.
@@ -60,6 +60,19 @@ git github.com/jumanjihouse/docker-caddy docker-caddy
 
 # Allow browsing in this dir.
 browse /docker-caddy
+
+# Requests to /assets actually go to caddy2 container.
+proxy /assets http://192.168.254.253:2020/ {
+  without /assets # Trim before proxying the request upstream.
+  transparent
+}
+
+# Cache assets for default time period.
+# https://caddyserver.com/docs/http.cache
+cache {
+  match_path /assets
+  path /dev/shm
+}
 
 # Headers for all paths to demonstrate reasonable safety.
 # This fixture does not use TLS, so we omit recommended headers for https.

--- a/src/plugins.patch
+++ b/src/plugins.patch
@@ -2,7 +2,8 @@ diff --git caddy/caddymain/run.go caddy/caddymain/run.go
 index 81f97f2..dc6bf9e 100644
 --- caddy/caddymain/run.go
 +++ caddy/caddymain/run.go
-@@ -37,0 +38,3 @@ import (
+@@ -37,0 +38,4 @@ import (
 +	_ "github.com/abiosoft/caddy-git"
 +	_ "blitznote.com/src/caddy.upload"
 +	_ "github.com/jung-kurt/caddy-cgi"
++	_ "github.com/nicolasazrak/caddy-cache"

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -1,0 +1,20 @@
+@test "cache plugin is installed" {
+  run docker-compose run --rm caddy -plugins
+  [[ "${output}" =~ http.cache ]]
+}
+
+@test "can fetch a proxied asset" {
+  curl_opts='--user-agent assets --fail -sS -L'
+
+  output="$(docker-compose run curl ${curl_opts} http://192.168.254.254:2020/assets/)" # cache miss
+  [[ "${output}" =~ 'hello world' ]]
+
+  output="$(docker-compose run curl ${curl_opts} http://192.168.254.254:2020/assets/)" # cache hit
+  [[ "${output}" =~ 'hello world' ]]
+}
+
+@test "log shows cache hits and misses" {
+  output="$(docker-compose logs caddy1 | grep -e assets)"
+  [[ "${output}" =~ miss ]]
+  [[ "${output}" =~ hit ]]
+}


### PR DESCRIPTION
New tests:

    bats test/cache.bats
     ✓ cache plugin is installed
     ✓ can fetch a proxied asset
     ✓ log shows cache hits and misses

    3 tests, 0 failures